### PR TITLE
Using Alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.1
 MAINTAINER Dave Newman <dave@assembly.com>
 
-RUN apk add --update py-pip && pip install awscli
+RUN apk add --update bash py-pip && pip install awscli
 ADD watch /watch
 
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:14.04
+FROM alpine:3.1
 MAINTAINER Dave Newman <dave@assembly.com>
 
-RUN apt-get update && apt-get install -y awscli
+RUN apk add --update py-pip && pip install awscli
 ADD watch /watch
 
 VOLUME /data


### PR DESCRIPTION
The Alpine base image is only 5MB, while the Ubuntu is 190MB.
