### PR TITLE
Resolved an issue with S3V4 keys

### DIFF
--- a/watch
+++ b/watch
@@ -1,4 +1,5 @@
 #!/bin/bash
+aws configure set s3.signature_version s3v4
 
 [[ "$TRACE" ]] && set -x
 


### PR DESCRIPTION
I ran into an issue when using s3-volume with my AWS bucket. 
The fix is based on the error message I received. 