### PR TITLE
Allow configuration of the endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Any environment variable available to the `aws-cli` command can be used. see
 http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html for more
 information.
 
+### Configuring an endpoint URL
+
+If you are using an S3-compatible service (such as Oracle OCI Object Storage), you may want to set the service's endpoint URL:
+
+```bash
+docker run -d --name my-data-container -e ENDPOINT_URL=... \
+           elementar/s3-volume /data s3://mybucket/someprefix
+```
+
 ### Forcing a sync
 
 A final sync will always be performed on container shutdown. A sync can be

--- a/watch
+++ b/watch
@@ -40,6 +40,12 @@ PROGNAME=$0
 LOCAL=$1
 REMOTE=$2
 
+if [ "$ENDPOINT_URL" ]; then
+  AWS="aws --endpoint-url $ENDPOINT_URL"
+else
+  AWS=aws
+fi
+
 function restore {
   if [ "$(ls -A $LOCAL)" ]; then
     if [[ ${FORCE_RESTORE:false} == 'true' ]]; then
@@ -48,14 +54,14 @@ function restore {
   fi
 
   echo "restoring $REMOTE => $LOCAL"
-  if ! aws s3 sync "$REMOTE" "$LOCAL"; then
+  if ! $AWS s3 sync "$REMOTE" "$LOCAL"; then
     error_exit "restore failed"
   fi
 }
 
 function backup {
   echo "backup $LOCAL => $REMOTE"
-  if ! aws s3 sync "$LOCAL" "$REMOTE" --delete; then
+  if ! $AWS s3 sync "$LOCAL" "$REMOTE" --delete; then
     echo "backup failed" 1>&2
     return 1
   fi
@@ -63,7 +69,7 @@ function backup {
 
 function final_backup {
   echo "backup $LOCAL => $REMOTE"
-  while ! aws s3 sync "$LOCAL" "$REMOTE" --delete; do
+  while ! $AWS s3 sync "$LOCAL" "$REMOTE" --delete; do
     echo "backup failed, will retry" 1>&2
     sleep 1
   done


### PR DESCRIPTION
Allows the configuration of the endpoint URL via env var ENDPOINT_URL in order to use this image with "S3-compatible" services such as [Oracle OCI Object Storage](https://docs.cloud.oracle.com/iaas/Content/Object/Tasks/s3compatibleapi.htm).