### PR TITLE
Health check support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.10
-label maintainer="Elementar Sistemas <contato@elementarsistemas.com.br>"
+LABEL maintainer="Malcolm Crum <crummynz@gmail.com>"
 
-RUN apk --no-cache add bash py3-pip && pip3 install --no-cache-dir awscli
+RUN apk --no-cache add bash py3-pip moreutils && \
+    pip3 install --no-cache-dir awscli
 ADD watch /watch
 
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 LABEL maintainer="Malcolm Crum <crummynz@gmail.com>"
 
-RUN apk --no-cache add bash py3-pip moreutils && \
+RUN apk --no-cache add bash py3-pip && \
     pip3 install --no-cache-dir awscli
 ADD watch /watch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD watch /watch
 
 VOLUME /data
 
-HEALTHCHECK --interval=1s --timeout=1s \
+HEALTHCHECK --interval=1s --timeout=60s --retries=3 \
 	CMD stat /var/healthy.txt || exit 1
 
 ENV S3_SYNC_FLAGS "--delete"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD watch /watch
 
 VOLUME /data
 
-HEALTHCHECK --interval=1s --timeout=60s --retries=3 \
+HEALTHCHECK --interval=2s --retries=120 \
 	CMD stat /var/healthy.txt || exit 1
 
 ENV S3_SYNC_FLAGS "--delete"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ADD watch /watch
 
 VOLUME /data
 
+HEALTHCHECK --interval=1s --timeout=1s \
+	CMD stat /var/healthy.txt || exit 1
+
 ENV S3_SYNC_FLAGS "--delete"
 ENTRYPOINT [ "./watch" ]
 CMD ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD watch /watch
 
 VOLUME /data
 
-HEALTHCHECK --interval=2s --retries=120 \
+HEALTHCHECK --interval=2s --retries=300 \
 	CMD stat /var/healthy.txt || exit 1
 
 ENV S3_SYNC_FLAGS "--delete"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME = crummy/s3-volume
 .PHONY: build release
 
 build:
-	docker build -t $(NAME):latest .
+	docker build --platform linux/amd64 -t $(NAME):latest .
 
 release:
 	docker push $(NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME = elementar/s3-volume
+NAME = crummy/s3-volume
 
 .PHONY: build release
 

--- a/watch
+++ b/watch
@@ -40,11 +40,16 @@ PROGNAME=$0
 LOCAL=$1
 REMOTE=$2
 HEALTHCHECK_FILE=/var/healthy.txt
+TIMESTAMPS="ts '[%Y-%m-%d %H:%M:%S]'"
 
 if [ "$ENDPOINT_URL" ]; then
   AWS="aws --endpoint-url $ENDPOINT_URL"
 else
-  AWS=aws
+  AWS="aws"
+fi
+
+if [ "$EXCLUDE_PATTERN" ]; then
+  S3_EXCLUDE_FLAGS="--exclude $EXCLUDE_PATTERN"
 fi
 
 function restore {
@@ -55,7 +60,7 @@ function restore {
   fi
 
   echo "restoring $REMOTE => $LOCAL"
-  if ! $AWS s3 sync "$REMOTE" "$LOCAL"; then
+  if ! $AWS s3 sync "$REMOTE" "$LOCAL" $EXCLUDE_PATTERN | $TIMESTAMPS; then
     error_exit "restore failed"
   fi
   touch $HEALTHCHECK_FILE
@@ -63,7 +68,7 @@ function restore {
 
 function backup {
   echo "backup $LOCAL => $REMOTE"
-  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS; then
+  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | $TIMESTAMPS; then
     echo "backup failed" 1>&2
     rm $HEALTHCHECK_FILE
     return 1
@@ -73,7 +78,7 @@ function backup {
 
 function final_backup {
   echo "backup $LOCAL => $REMOTE"
-  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS; do
+  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | $TIMESTAMPS; do
     echo "backup failed, will retry" 1>&2
     sleep 1
   done

--- a/watch
+++ b/watch
@@ -60,7 +60,7 @@ function restore {
   fi
 
   echo "restoring $REMOTE => $LOCAL"
-  if ! $AWS s3 sync "$REMOTE" "$LOCAL" $EXCLUDE_PATTERN | ts '[%F %T]'; then
+  if ! $AWS s3 sync "$REMOTE" "$LOCAL" $EXCLUDE_PATTERN; then
     error_exit "restore failed"
   fi
   touch $HEALTHCHECK_FILE
@@ -68,7 +68,7 @@ function restore {
 
 function backup {
   echo "backup $LOCAL => $REMOTE"
-  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | ts '[%F %T]'; then
+  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN; then
     echo "backup failed" 1>&2
     rm $HEALTHCHECK_FILE
     return 1
@@ -78,7 +78,7 @@ function backup {
 
 function final_backup {
   echo "backup $LOCAL => $REMOTE"
-  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | ts '[%F %T]'; do
+  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN; do
     echo "backup failed, will retry" 1>&2
     sleep 1
   done

--- a/watch
+++ b/watch
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 [[ "$TRACE" ]] && set -x
 
@@ -40,7 +41,6 @@ PROGNAME=$0
 LOCAL=$1
 REMOTE=$2
 HEALTHCHECK_FILE=/var/healthy.txt
-TIMESTAMPS="ts '[%Y-%m-%d %H:%M:%S]'"
 
 if [ "$ENDPOINT_URL" ]; then
   AWS="aws --endpoint-url $ENDPOINT_URL"
@@ -60,7 +60,7 @@ function restore {
   fi
 
   echo "restoring $REMOTE => $LOCAL"
-  if ! $AWS s3 sync "$REMOTE" "$LOCAL" $EXCLUDE_PATTERN | $TIMESTAMPS; then
+  if ! $AWS s3 sync "$REMOTE" "$LOCAL" $EXCLUDE_PATTERN | ts '[%F %T]'; then
     error_exit "restore failed"
   fi
   touch $HEALTHCHECK_FILE
@@ -68,7 +68,7 @@ function restore {
 
 function backup {
   echo "backup $LOCAL => $REMOTE"
-  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | $TIMESTAMPS; then
+  if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | ts '[%F %T]'; then
     echo "backup failed" 1>&2
     rm $HEALTHCHECK_FILE
     return 1
@@ -78,7 +78,7 @@ function backup {
 
 function final_backup {
   echo "backup $LOCAL => $REMOTE"
-  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | $TIMESTAMPS; do
+  while ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS $EXCLUDE_PATTERN | ts '[%F %T]'; do
     echo "backup failed, will retry" 1>&2
     sleep 1
   done

--- a/watch
+++ b/watch
@@ -39,6 +39,7 @@ done
 PROGNAME=$0
 LOCAL=$1
 REMOTE=$2
+HEALTHCHECK_FILE=/var/healthy.txt
 
 if [ "$ENDPOINT_URL" ]; then
   AWS="aws --endpoint-url $ENDPOINT_URL"
@@ -57,14 +58,17 @@ function restore {
   if ! $AWS s3 sync "$REMOTE" "$LOCAL"; then
     error_exit "restore failed"
   fi
+  touch $HEALTHCHECK_FILE
 }
 
 function backup {
   echo "backup $LOCAL => $REMOTE"
   if ! $AWS s3 sync "$LOCAL" "$REMOTE" $S3_SYNC_FLAGS; then
     echo "backup failed" 1>&2
+    rm $HEALTHCHECK_FILE
     return 1
   fi
+  touch $HEALTHCHECK_FILE
 }
 
 function final_backup {


### PR DESCRIPTION
# Problem

I want to know when the initial sync is completed, so I can safely boot up dependent containers that rely on these files.

# Solution

Add health check support:

* When initial sync is complete, write a file to the container's file system
* Point the health check configuration to check for the existence of this file
* During backups, if a backup fails, remove the file (this one isn't essential for my needs but seems part of a health check feature)